### PR TITLE
Fix older print device models using the output mode for color option

### DIFF
--- a/lib/attributes.js
+++ b/lib/attributes.js
@@ -244,6 +244,7 @@ attributes["Document Template"] = {
   "media-input-tray-check":                       _(keyword, name),
   "number-up":                                    integer(1,MAX),
   "orientation-requested":                        enumeration,
+  "output-mode":                                  keyword,
   "overrides":                                    setof(collection({
     //Any Document Template attribute (TODO)
 		"document-copies":                            setof(rangeOfInteger),
@@ -494,6 +495,7 @@ attributes["Job Template"] = {
   "orientation-requested":                        enumeration,
   "output-bin":                                   _(keyword, name),
   "output-device":                                name(127),
+  "output-mode":                                  keyword,
   "overrides":                                    setof(collection({
     //Any Job Template attribute (TODO)
 		"document-copies":                            setof(rangeOfInteger),
@@ -764,6 +766,8 @@ attributes["Operation"] = {
   "output-bin-default":                           _(keyword, name),
   "output-bin-supported":                         setof(_(keyword, name)),
   "output-device-supported":                      setof(name(127)),
+  "output-mode-default":                          keyword,
+  "output-mode-supported":                        setof(keyword),
   "overrides-supported":                          setof(keyword),
   "page-delivery-default":                        keyword,
   "page-delivery-supported":                      setof(keyword),

--- a/lib/keywords.js
+++ b/lib/keywords.js
@@ -1183,6 +1183,21 @@ keywords["output-bin-default"] = keyword_name(
 keywords["output-bin-supported"] = setof_keyword_name(
   keywords["output-bin"]
 );
+keywords["output-mode"] = keyword([
+  "auto",
+  "bi-level",
+  "color",
+  "highlight",
+  "monochrome",
+  "process-bi-level",
+  "process-monochrome"
+]);
+keywords["output-mode-default"] = keyword(
+  keywords["output-mode"]
+);
+keywords["output-mode-supported"] = setof_keyword(
+  keywords["output-mode"]
+);
 keywords["page-delivery"] = keyword([
   "reverse-order-face-down",
   "reverse-order-face-up",


### PR DESCRIPTION
Adding output mode to the keywords and attributes to fix the older Print Devices with printing in color.